### PR TITLE
Normalize CSSWL scorer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
   - "2.7"
   - "3.4"
+addons:
+  apt:
+    packages:
+    - gcc
 # Setup anaconda for easily running scipy on Travis; see https://gist.github.com/dan-blanchard/7045057
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: python
 python:
   - "2.7"
   - "3.4"
-addons:
-  apt:
-    packages:
-    - gcc
 # Setup anaconda for easily running scipy on Travis; see https://gist.github.com/dan-blanchard/7045057
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,22 @@ python:
   - "3.4"
 # Setup anaconda for easily running scipy on Travis; see https://gist.github.com/dan-blanchard/7045057
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda2/bin:$PATH
+  # Commands below copied from: http://conda.pydata.org/docs/travis.html
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  # reset the shell's lookup table for program name to path mappings
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
 install:
   - conda update --yes conda
   - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose pandas matplotlib scikit-bio libgfortran

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Topeology compares neoepitope sequences with epitopes from [IEDB](http://www.iedb.org/).
 
-This software is **not** currently ready for production use.
-
 ## Example
 
 From the command line:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ extensions = []
 if seq_align_path:
     seq_align_dirs = [path.join(seq_align_path, 'src'),
                       path.join(seq_align_path, 'libs'),
-                      path.join(seq_align_path, 'libs/bit_array'),
                       path.join(seq_align_path, 'libs/string_buffer')]
     pmbec_align = Extension('pmbecalign',
                             include_dirs=seq_align_dirs,
@@ -49,7 +48,6 @@ if seq_align_path:
                             libraries=[
                                 'align',
                                 'strbuf',
-                                'bitarr',
                                 'pthread',
                                 'z'
                             ],

--- a/test/test_topeology.py
+++ b/test/test_topeology.py
@@ -18,6 +18,15 @@ def test_single_comparison():
     # TODO: This score is currently unverified
     eq_(df_scores.score.max(), 2.38)
 
+def test_single_comparison_ignore_seqalign():
+    df = pd.DataFrame({'Sample': '001',
+                       'epitope': ['AAALPGKCGV'],
+                       'iedb_epitope': ['EFKEFAAGRR']})
+    df_scores = calculate_similarity_from_df(df, ignore_seqalign=True)
+
+    # TODO: This score is currently unverified
+    eq_(df_scores.score.max(), 2.38)
+
 def test_calculate_similarity():
     df_scores = compare(epitope_file_path=TEST_EPITOPES,
                         epitope_lengths=[8, 9, 10, 11])

--- a/topeology/scorers.py
+++ b/topeology/scorers.py
@@ -40,7 +40,9 @@ class CSSWLScorer(Scorer):
             seq_a, protein=True,
             gap_open_penalty=self.gap_penalty, gap_extend_penalty=self.gap_penalty,
             substitution_matrix=self.aa.as_int_dict())
-        return query(seq_b)["optimal_alignment_score"]
+
+        # Normalize to be in line with SeqAlignScorer
+        return query(seq_b)["optimal_alignment_score"] / 100.
 
 class SeqAlignScorer(Scorer):
     """Use the seq-align library, via the pmbecalign C extension, to align seq_a and seq_b."""


### PR DESCRIPTION
In this PR:

* Normalize CSSWLScorer to be in line with SeqAlignScorer. Add a related test.
* Fix conda installation in `.travis.yml`.
* Fix `seq-align` installation in `setup.py` to remove `bit_array`, which was removed in `seq-align`.
* Remove the production use warning from the `README`.